### PR TITLE
Remove keyset table.

### DIFF
--- a/lib/lazy_cache.ex
+++ b/lib/lazy_cache.ex
@@ -21,25 +21,16 @@ defmodule LazyCache do
 
   Returns a boolean indicating if element has been correctly inserted.
   """
+  @spec insert(term(), term(), :keep_alive_forever | number()) :: true | {:error, String.t()}
   def insert(key, value, keepAliveInMillis \\ :keep_alive_forever) do
     if not check_valid_keep_alive(keepAliveInMillis) do
       {:error,
        "Keep Alive Time is not valid. Should be a positive Integer or :keep_alive_forever."}
     else
-      is_inserted =
-        :ets.insert(
-          :buckets_registry,
-          {key, value, get_keepalive(keepAliveInMillis)}
-        )
-
-      get_keyset()
-      |> check_if_key_already_in_keyset(key)
-
-      if is_inserted do
-        append_to_keyset(get_keyset(), key)
-      end
-
-      is_inserted
+      :ets.insert(
+        :buckets_registry,
+        {key, value, get_keepalive(keepAliveInMillis)}
+      )
     end
   end
 
@@ -58,13 +49,7 @@ defmodule LazyCache do
   Returns a boolean indicating if element has been correctly deleted.
   """
   def delete(key) do
-    is_deleted = :ets.delete(:buckets_registry, key)
-
-    if is_deleted do
-      delete_from_keyset(get_keyset(), key)
-    end
-
-    is_deleted
+    :ets.delete(:buckets_registry, key)
   end
 
   @doc """
@@ -74,7 +59,7 @@ defmodule LazyCache do
   """
   @spec size() :: integer
   def size() do
-    length(get_keyset())
+    :ets.select_count(:buckets_registry, [{{:_, :_, :_}, [], [true]}])
   end
 
   @doc """
@@ -84,20 +69,12 @@ defmodule LazyCache do
   """
   @spec clear() :: boolean
   def clear() do
-    if size() == 0 do
-      false
-    else
-      for key <- get_keyset(), do: delete(key)
-      true
-    end
+    :ets.delete_all_objects(:buckets_registry)
   end
 
+  defp get_keepalive(:keep_alive_forever), do: :keep_alive_forever
   defp get_keepalive(keepAliveInMillis) do
-    if keepAliveInMillis == :keep_alive_forever do
-      :keep_alive_forever
-    else
-      :os.system_time(:milli_seconds) + keepAliveInMillis
-    end
+    :os.system_time(:millisecond) + keepAliveInMillis
   end
 
   defp check_valid_keep_alive(keepAliveInMillis) do
@@ -106,43 +83,9 @@ defmodule LazyCache do
          (is_integer(keepAliveInMillis) and keepAliveInMillis > 0))
   end
 
-  defp update_key_set(key_set) do
-    :ets.delete(:key_set, :keys)
-    :ets.insert(:key_set, {:keys, key_set})
-  end
-
-  defp check_if_key_already_in_keyset(key_set, key) do
-    if Enum.member?(key_set, key) do
-      delete_from_keyset(key_set, key)
-    end
-  end
-
-  defp delete_from_keyset(key_set, key) do
-    List.delete(key_set, key)
-    |> update_key_set()
-  end
-
-  defp append_to_keyset(key_set, key) do
-    (key_set ++ [key])
-    |> update_key_set()
-  end
-
-  defp purge(key) do
-    [element] = lookup(key)
-
-    if(elem(element, 2) <= :os.system_time(:milli_seconds)) do
-      delete(key)
-    end
-  end
-
   defp purge_cache() do
-    if size() > 0 do
-      for key <- get_keyset(), do: purge(key)
-    end
-  end
-
-  defp get_keyset() do
-    :ets.lookup(:key_set, :keys)[:keys]
+    now = :os.system_time(:millisecond)
+    :ets.select_delete(:buckets_registry, [{{:_, :_, :"$1"}, [{:is_number, :"$1"}, {:"=<", :"$1", now}], [true]}])
   end
 
   @impl true
@@ -151,8 +94,6 @@ defmodule LazyCache do
     schedule_work()
     # Create table
     :ets.new(:buckets_registry, [:set, :public, :named_table])
-    :ets.new(:key_set, [:set, :public, :named_table])
-    :ets.insert(:key_set, {:keys, []})
     {:ok, state}
   end
 

--- a/test/lazy_cache_test.exs
+++ b/test/lazy_cache_test.exs
@@ -1,6 +1,5 @@
 defmodule LazyCacheTest do
-  use ExUnit.Case
-  doctest LazyCache
+  use ExUnit.Case, async: true
 
   def keep_alive_error() do
     "Keep Alive Time is not valid. Should be a positive Integer or :keep_alive_forever."
@@ -53,32 +52,10 @@ defmodule LazyCacheTest do
     assert LazyCache.size() == 0
   end
 
-  test "should decrease cache size when delete" do
-    LazyCache.start()
-    LazyCache.insert("key", "value", 1000)
-    LazyCache.delete("key")
-    refute LazyCache.size() == 1
-  end
-
   test "ensure data exists when inserted" do
     LazyCache.start()
     LazyCache.insert("key", "value", 1000)
-    [data] = LazyCache.lookup("key")
-    refute data == nil
-  end
-
-  test "ensure data key persists when inserted" do
-    LazyCache.start()
-    LazyCache.insert("key", "value", 1000)
-    [data] = LazyCache.lookup("key")
-    assert elem(data, 0) == "key"
-  end
-
-  test "ensure data value persists when inserted" do
-    LazyCache.start()
-    LazyCache.insert("key", "value", 1000)
-    [data] = LazyCache.lookup("key")
-    assert elem(data, 1) == "value"
+    assert [{"key", "value", _}] = LazyCache.lookup("key")
   end
 
   test "ensure data cannot be lookout when deleted" do
@@ -93,12 +70,6 @@ defmodule LazyCacheTest do
     LazyCache.insert("key", "value", 1000)
     LazyCache.clear()
     assert LazyCache.lookup("key") == []
-  end
-
-  test "nothing is cleared when no data in cache" do
-    LazyCache.start()
-    LazyCache.clear()
-    assert LazyCache.clear() == false
   end
 
   test "if there is data, cache is correctly cleared" do


### PR DESCRIPTION
The buckets_registry table is already a set, so inserting the same key will just update the value and keepAlive time. ETS also has functions to count and delete the objects in the table, so there's no need to maintain a set of key (or reorder them at all).